### PR TITLE
Temporarily enable prerelease for rendering7

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -201,6 +201,9 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+            # Temporarily enable pre-prelease to get access to OGRE 2.3 debs
+          - name: osrf
+            type: prerelease
     - name: ignition-sensors7
       repositories:
           - name: osrf


### PR DESCRIPTION
OGRE 2.3 debs are located in prerelease (https://build.osrfoundation.org/job/ogre-2.3-debbuilder/27/), so enable it to get rendering7 tested:

* https://github.com/gazebosim/gz-cmake/pull/283
* https://github.com/gazebosim/gz-rendering/pull/553

Signed-off-by: Michael Carroll <michael@openrobotics.org>