### PR TITLE
Use prerelease in gz-rendering8

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -86,6 +86,12 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+    - name: gz-rendering8
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
     - name: gz-sensors8
       repositories:
           - name: osrf


### PR DESCRIPTION
This updates gz-rendering8 to use the prerelease repos so we can test the new version of libogre-next-2.3 that was just released (see https://github.com/gazebosim/gz-sim/issues/920#issuecomment-1716429220)