### PR TITLE
Replace apt-key with keyring installation (take II)

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -33,8 +33,9 @@ jobs:
           python3 plugins/*_TEST.py
       - name: Smoke system tests
         run: |
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+            python3 ./gzdev.py repository enable osrf stable
           python3 gzdev.py repository list
-          python3 gzdev.py repository enable osrf stable
           python3 gzdev.py ign-docker-env citadel
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:focal --vol /tmp:/foo::/tmp:/bar --rocker-args '--dev-helpers'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,6 +34,7 @@ jobs:
       - name: Smoke system tests
         run: |
           python3 gzdev.py repository list
+          python3 gzdev.py repository enable osrf stable
           python3 gzdev.py ign-docker-env citadel
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:focal --vol /tmp:/foo::/tmp:/bar --rocker-args '--dev-helpers'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,7 +27,7 @@ jobs:
           # stop the build if there are Python syntax errors or undefined names
           flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
           # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-          flake8 . --count --ignore=D101,D102,D103 --max-complexity=10 --max-line-length=127 --statistics
+          flake8 . --count --ignore=D101,D102,D103,W503 --max-complexity=10 --max-line-length=127 --statistics
       - name: Test plugins _TEST.py
         run: |
           python3 plugins/*_TEST.py

--- a/plugins/config/_test_repository.yaml
+++ b/plugins/config/_test_repository.yaml
@@ -3,6 +3,7 @@
 repositories:
     - name: osrf
       key: ABC1234567890
+      key_url: https://lala/foo.gpg
       linux_distro: ubuntu
       types:
           - name: stable
@@ -11,6 +12,7 @@ repositories:
             url: http://prerelease-ubuntu
     - name: osrf
       key: ABC1234567890
+      key_url: https://lala/foo.gpg
       linux_distro: debian
       types:
           - name: stable

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -2,6 +2,7 @@
 repositories:
     - name: osrf
       key: D2486D2DD83DB69272AFE98867170598AF249743
+      key_url: https://packages.osrfoundation.org/gazebo.gpg
       linux_distro: ubuntu
       types:
           - name: stable
@@ -12,6 +13,7 @@ repositories:
             url: http://packages.osrfoundation.org/gazebo/ubuntu-nightly
     - name: osrf
       key: D2486D2DD83DB69272AFE98867170598AF249743
+      key_url: https://packages.osrfoundation.org/gazebo.gpg
       linux_distro: debian
       types:
           - name: stable

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -205,7 +205,7 @@ def normalize_args(args):
 
 
 def validate_input(args):
-    if args.keyserver:
+    if 'keyserver' in args:
         warn('--keyserver option is deprecated. It is safe to remove it')
 
     if (args.action == 'enable'

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -21,11 +21,13 @@ Options:
         --version               Show gzdev's version
 """
 
+import os
 import pathlib
 import re
 import subprocess
 import sys
-from os.path import isfile
+import urllib.error
+import urllib.request
 
 from docopt import docopt
 
@@ -88,6 +90,14 @@ def get_repo_key(repo_name, config):
     error('No key in repo: ' + repo_name)
 
 
+def get_repo_key_url(repo_name, config):
+    for p in config['repositories']:
+        if p['name'] == repo_name:
+            return p['key_url']
+
+    error('No key in repo: ' + repo_name)
+
+
 def get_repo_url(repo_name, repo_type, config):
     for p in config['repositories']:
         if p['name'] == repo_name and p['linux_distro'].lower() == get_linux_distro():
@@ -104,44 +114,79 @@ def get_sources_list_file_path(repo_name, repo_type):
     return directory + '/' + filename
 
 
-def install_key(key, keyserver):
-    _check_call(['apt-key', 'adv',
-                 '--keyserver', keyserver,
-                 '--recv-keys', key])
+def key_filepath(repo_name, repo_type):
+    return f"/usr/share/keyrings/{repo_name}_{repo_type}.gpg"
+
+
+def assert_key_in_file(key, key_path):
+    output = subprocess.check_output(
+        ['gpg', '--show-keys', key_path])
+
+    print(output.decode("ascii"))
+    if key not in output.decode("ascii"):
+        error(f"Key {key} was not found in file {key_path}")
+
+
+def download_key(repo_name, repo_type, key_url):
+    key_path = key_filepath(repo_name, repo_type)
+    if os.path.exists(key_path):
+        warn(f"keyring gpg file already exists in the system: {key_path}\n"
+             "Overwritting to grab the new one.")
+        os.remove(key_path)
+    try:
+        response = urllib.request.urlopen(key_url)
+        if response.code == 200:
+            with open(key_path, "wb") as file:
+                file.write(response.read())
+        else:
+            error(response.code)
+    except urllib.error.HTTPError as e:
+        error(f"HTTPError: {e.code}")
+    except urllib.error.URLError as e:
+        error(f"URLError: {e.reason}")
+
+    return key_path
+
+
+def remove_deprecated_apt_key(key):
+    _check_call(['apt-key', 'del', key])
 
 
 def run_apt_update():
     _check_call(['apt-get', 'update'])
 
 
-def install_repos(project_list, config, linux_distro, keyserver):
+def install_repos(project_list, config, linux_distro):
     for p in project_list:
-        install_repo(p['name'], p['type'], config, linux_distro, keyserver)
+        install_repo(p['name'], p['type'], config, linux_distro)
 
 
-def install_repo(repo_name, repo_type, config, linux_distro, keyserver):
+def install_repo(repo_name, repo_type, config, linux_distro):
     url = get_repo_url(repo_name, repo_type, config)
     key = get_repo_key(repo_name, config)
-    # if not linux_distro provided, try to guess it
-    if not linux_distro:
-        linux_distro = distro.codename()
-    content = 'deb ' + url + ' ' + linux_distro + ' main\n'
-    full_path = get_sources_list_file_path(repo_name, repo_type)
-
-    if isfile(full_path):
-        warn('gzdev file with the repositoy already exists in the system\n[' + full_path + ']')
-        return
-
-    install_key(key, keyserver)
+    key_url = get_repo_key_url(repo_name, config)
 
     try:
+        key_path = download_key(repo_name, repo_type, key_url)
+        assert_key_in_file(key, key_path)
+
+        # if not linux_distro provided, try to guess it
+        if not linux_distro:
+            linux_distro = distro.codename()
+
+        content = f"deb [signed-by={key_path}] {url} {linux_distro} main"
+        full_path = get_sources_list_file_path(repo_name, repo_type)
+        if os.path.isfile(full_path):
+            warn("gzdev file with the repositoy already exists in the system:"
+                 f"{full_path}. \n Overwritting to use new signed-by.")
+
         f = open(full_path, 'w')
         f.write(content)
         f.close()
-    except PermissionError:
-        print('No permissiong to install ' + full_path + '. Run the script with sudo.')
 
-    run_apt_update()
+        run_apt_update()
+    except PermissionError:
+        print('No permissiong to make system file modifications. Run the script with sudo.')
 
 
 def disable_repo(repo_name):
@@ -158,14 +203,12 @@ def normalize_args(args):
         linux_distro = force_linux_distro
     else:
         linux_distro = None
-    keyserver = args['--keyserver'] if args['--keyserver'] else \
-        'keyserver.ubuntu.com'
 
-    return action, repo_name, repo_type, project, linux_distro, keyserver
+    return action, repo_name, repo_type, project, linux_distro
 
 
 def validate_input(args, config):
-    action, repo_name, repo_type, project, force_linux_distro, keyserver = args
+    action, repo_name, repo_type, project, force_linux_distro = args
 
     if (action == 'enable' or action == 'disable' or action == 'list'):
         pass
@@ -174,14 +217,14 @@ def validate_input(args, config):
 
 
 def process_input(args, config):
-    action, repo_name, repo_type, project, linux_distro, keyserver = args
+    action, repo_name, repo_type, project, linux_distro = args
 
     if (action == 'enable'):
         if project:
             project_list = load_project(project, config)
-            install_repos(project_list, config, linux_distro, keyserver)
+            install_repos(project_list, config, linux_distro)
         else:
-            install_repo(repo_name, repo_type, config, linux_distro, keyserver)
+            install_repo(repo_name, repo_type, config, linux_distro)
     elif (action == 'disable'):
         disable_repo(repo_name)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -113,7 +113,7 @@ def get_sources_list_file_path(repo_name, repo_type):
 
 
 def key_filepath(repo_name, repo_type):
-    return f"/usr/share/keyrings/{repo_name}_{repo_type}.gpg"
+    return f"/usr/share/keyrings/_gzdev_{repo_name}_{repo_type}.gpg"
 
 
 def assert_key_in_file(key, key_path):

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -200,14 +200,12 @@ def normalize_args(args):
         linux_distro = force_linux_distro
     else:
         linux_distro = None
-
+    if '--keyserver' in args:
+        warn('--keyserver option is deprecated. It is safe to remove it')
     return action, repo_name, repo_type, project, linux_distro
 
 
 def validate_input(args):
-    if '--keyserver' in args:
-        warn('--keyserver option is deprecated. It is safe to remove it')
-
     if 'enable' or 'disable' or 'list' in args['ACTION']:
         pass
     else:

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -205,12 +205,10 @@ def normalize_args(args):
 
 
 def validate_input(args):
-    if 'keyserver' in args:
+    if '--keyserver' in args:
         warn('--keyserver option is deprecated. It is safe to remove it')
 
-    if (args.action == 'enable'
-            or args.action == 'disable'
-            or args.action == 'list'):
+    if 'enable' or 'disable' or 'list' in args['ACTION']:
         pass
     else:
         error('Unknown action: ' + args.action)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -208,9 +208,9 @@ def validate_input(args):
     if args.keyserver:
         warn('--keyserver option is deprecated. It is safe to remove it')
 
-    if (args.action == 'enable' or
-            args.action == 'disable' or
-            args.action == 'list'):
+    if (args.action == 'enable'
+            or args.action == 'disable'
+            or args.action == 'list'):
         pass
     else:
         error('Unknown action: ' + args.action)

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -31,12 +31,7 @@ from docopt import docopt
 
 import yaml
 
-# python3-distro is not available in Xenial. platform is deprecated
-# in favor of distro
-try:
-    import distro
-except ImportError:
-    import platform
+import distro
 
 
 def _check_call(cmd):
@@ -81,28 +76,8 @@ def load_project(project, config):
     error('Unknown project: ' + project)
 
 
-def get_linux_distro_version():
-    # Handle both: distro module and old platform
-    try:
-        return distro.codename()
-    except NameError:
-        return platform.linux_distribution()[2]
-
-
 def get_linux_distro():
-    # Handle both: distro module and old platform
-    try:
-        distro_str = distro.id()
-    except NameError:
-        distro_str = platform.linux_distribution()[0]
-
-    # Probably not necessary with distro.id, but retained for compatibility
-    if 'Debian' in distro_str:
-        return 'debian'
-    elif 'Ubuntu' in distro_str:
-        return 'ubuntu'
-    else:
-        return distro_str.lower()
+    return distro.id().lower()
 
 
 def get_repo_key(repo_name, config):
@@ -149,7 +124,7 @@ def install_repo(repo_name, repo_type, config, linux_distro, keyserver):
     key = get_repo_key(repo_name, config)
     # if not linux_distro provided, try to guess it
     if not linux_distro:
-        linux_distro = get_linux_distro_version()
+        linux_distro = distro.codename()
     content = 'deb ' + url + ' ' + linux_distro + ' main\n'
     full_path = get_sources_list_file_path(repo_name, repo_type)
 

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -204,13 +204,16 @@ def normalize_args(args):
     return action, repo_name, repo_type, project, linux_distro
 
 
-def validate_input(args, config):
-    action, repo_name, repo_type, project, force_linux_distro = args
+def validate_input(args):
+    if args.keyserver:
+        warn('--keyserver option is deprecated. It is safe to remove it')
 
-    if (action == 'enable' or action == 'disable' or action == 'list'):
+    if (args.action == 'enable' or
+            args.action == 'disable' or
+            args.action == 'list'):
         pass
     else:
-        error('Unknown action: ' + action)
+        error('Unknown action: ' + args.action)
 
 
 def process_input(args, config):
@@ -228,9 +231,10 @@ def process_input(args, config):
 
 def main():
     try:
-        args = normalize_args(docopt(__doc__, version='gzdev-repository 0.2.0'))
+        args = normalize_args(docopt(__doc__,
+                                     version='gzdev-repository 0.2.0'))
         config = load_config_file()
-        validate_input(args, config)
+        validate_input(args)
         process_input(args, config)
     except KeyboardInterrupt:
         print('repository was stopped with a Keyboard Interrupt.\n')

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -21,6 +21,7 @@ Options:
         --version               Show gzdev's version
 """
 
+import distro
 import os
 import pathlib
 import re
@@ -28,12 +29,9 @@ import subprocess
 import sys
 import urllib.error
 import urllib.request
-
-from docopt import docopt
-
 import yaml
 
-import distro
+from docopt import docopt
 
 
 def _check_call(cmd):
@@ -122,7 +120,6 @@ def assert_key_in_file(key, key_path):
     output = subprocess.check_output(
         ['gpg', '--show-keys', key_path])
 
-    print(output.decode("ascii"))
     if key not in output.decode("ascii"):
         error(f"Key {key} was not found in file {key_path}")
 
@@ -231,7 +228,7 @@ def process_input(args, config):
 
 def main():
     try:
-        args = normalize_args(docopt(__doc__, version='gzdev-repository 0.1.0'))
+        args = normalize_args(docopt(__doc__, version='gzdev-repository 0.2.0'))
         config = load_config_file()
         validate_input(args, config)
         process_input(args, config)


### PR DESCRIPTION
Second take of #74. Reproducing the text here:

As the `apt-key` man pages recommends, this PR  removes the use of it and replaces it with a `Signed-By` clause that points to a download gpg key.

The PR adds the `key_url` field to yaml to store the URI to grab the key from. The `key`field is still preserve to check that the key stored has the expected fringerprint to improve the security. 

The tool will replace:
 * Automatically the files under `/etc/apt/config.d/sources.list.d/_gzdev_` files if they exist with a new one using the `signed-by` clause.
 * Previous gzdev installation of gpg keys inside `/usr/share/keyring`

The tool will not replace:
 * Any key authorized before using `apt-key` or other method.