### PR TITLE
Revert "Use pre-releases for gz-sim8 to test gz-msgs 10.1.0 (#77)"

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -130,13 +130,6 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    # Use pre-releases for gz-sim for testing gz-msgs 10.1.0
-    - name: gz-sim8
-      repositories:
-          - name: osrf
-            type: stable
-          - name: osrf
-            type: prerelease
     # generic regexp
     - name: gazebo.*
       repositories:


### PR DESCRIPTION
This reverts commit 70b78ffeff9268d6cf21fa5cf0242ba8109ab5d3 since gz-msgs 10.1.0  is being released.