### PR TITLE
Use prerelease for Harmonic / Noble libraries

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -26,6 +26,160 @@ repositories:
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
+    # Harmonic use prerelease on Noble
+    - name: gz-harmonic
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-cmake3
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-common5
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-fuel-tools9
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-sim8
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-gui8
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-launch7
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-math7
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-msgs10
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-physics7
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-plugin2
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-rendering8
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-sensors8
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-tools2
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-transport13
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: gz-utils2
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
+    - name: sdformat14
+      distributions:
+        ubuntu:
+          - noble
+      repositories:
+        - name: osrf
+          type: stable
+        - name: osrf
+          type: prerelease
     # Remove gz-ionic when Ionic is released
     - name: gz-ionic1
       repositories:


### PR DESCRIPTION
Add the Harmonic libraries with the requirement to run on Noble to make use of the prerelease repository.

Tested https://build.osrfoundation.org/job/_test_gz_math-ci-gz-math7-noble-amd64/11/console . Although Noble is quite broken at this moment, the log shows that the prerelease repository is being used.