### PR TITLE
Implement purge/--pre-cleanup option

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -31,11 +31,19 @@ jobs:
       - name: Test plugins _TEST.py
         run: |
           python3 plugins/*_TEST.py
-      - name: Smoke system tests
+      - name: Smoke system tests for repository module
         run: |
-          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
-            python3 ./gzdev.py repository enable osrf stable
           python3 gzdev.py repository list
+          repo_to_test="osrf"
+          repo_type_to_test="stable"
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+              python3 ./gzdev.py repository enable ${repo_to_test} ${repo_type_to_test}
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+             python3 ./gzdev.py repository --pre-cleanup enable ${repo_to_test} ${repo_type_to_test} >log
+          grep "/etc/apt/sources.list.d/_gzdev_${repo_to_test}_${repo_type_to_test}.list" log
+          grep "/usr/share/keyrings/_gzdev_${repo_to_test}_${repo_type_to_test}.gpg" log
+      - name: Smoke system tests for ign-docker module
+        run: |
           python3 gzdev.py ign-docker-env citadel
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:bionic
           python3 gzdev.py ign-docker-env dome --linux-distro ubuntu:focal --vol /tmp:/foo::/tmp:/bar --rocker-args '--dev-helpers'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -36,10 +36,18 @@ jobs:
           python3 gzdev.py repository list
           repo_to_test="osrf"
           repo_type_to_test="stable"
+          # Test --pre-cleanup
           sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
               python3 ./gzdev.py repository enable ${repo_to_test} ${repo_type_to_test}
           sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
              python3 ./gzdev.py repository --pre-cleanup enable ${repo_to_test} ${repo_type_to_test} >log
+          grep "/etc/apt/sources.list.d/_gzdev_${repo_to_test}_${repo_type_to_test}.list" log
+          grep "/usr/share/keyrings/_gzdev_${repo_to_test}_${repo_type_to_test}.gpg" log
+          # Test the purge action
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+              python3 ./gzdev.py repository enable ${repo_to_test} ${repo_type_to_test}
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+             python3 ./gzdev.py repository purge
           grep "/etc/apt/sources.list.d/_gzdev_${repo_to_test}_${repo_type_to_test}.list" log
           grep "/usr/share/keyrings/_gzdev_${repo_to_test}_${repo_type_to_test}.gpg" log
       - name: Smoke system tests for ign-docker module

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -15,6 +15,7 @@ Action:
         enable                  Enable repository in the system
         disable                 Disable repository (if present)
         list                    List repositories enabled
+        purge                   Remove all configurations installed by gzdev
 
 Options:
         -h --help               Show this screen
@@ -22,8 +23,7 @@ Options:
         --gpg-check             Do run a gpg check for validating the key
                                 downloaded in enable action
                                 (need the gpg binary)
-        --pre-cleanup           Remove all repositories and keys installed
-                                by gzdev from the system before proceding
+        --pre-cleanup           Run 'purge' action before proceeding
 """
 
 import distro
@@ -225,6 +225,9 @@ def normalize_args(args):
     force_linux_distro = args['--force-linux-distro']
     gpg_check = args['--gpg_check'] if '--gpg_check' in args else False
     pre_cleanup = args['--pre-cleanup'] if '--pre-cleanup' in args else False
+    if pre_cleanup and action != 'enable':
+        error('--pre-cleanup is only supported in the "enable" action'
+              f'(not in {action})')
     if force_linux_distro:
         linux_distro = force_linux_distro
     else:
@@ -277,6 +280,8 @@ def process_input(args, config):
                          gpg_check)
     elif (action == 'disable'):
         disable_repo(repo_name)
+    elif (action == 'purge'):
+        remove_all_installed()
 
 
 def remove_file_by_pattern(directory, pattern):


### PR DESCRIPTION
Add a `--pre-clean` option that removes any existing gzdev installation from the system before proceeding with the next actions.