### PR TITLE
Add prereleases Ionic branches

### DIFF
--- a/gzdev.py
+++ b/gzdev.py
@@ -26,7 +26,7 @@ from sys import stderr
 from docopt import docopt
 
 if __name__ == '__main__':
-    args = docopt(__doc__, version='gzdev-core 0.1.0', options_first=True)
+    args = docopt(str(__doc__), version='gzdev-core 0.1.0', options_first=True)
     cmd = args['<command>']
     is_valid = {'ign-docker-env': True,
                 'repository': True}

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -33,11 +33,13 @@ projects:
             type: stable
           - name: osrf
             type: nightly
-    # Use nightlies in all main branches
+    # Use prereleases and nightlies in Ionic main branches
     - name: gz-cmake4
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-common6
@@ -45,11 +47,15 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-msgs11
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-fuel-tools10
@@ -57,11 +63,15 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-sim9
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-gui9
@@ -69,11 +79,15 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-launch8
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-math8
@@ -81,11 +95,15 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-physics8
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-plugin3
@@ -93,11 +111,15 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-rendering9
       repositories:
           - name: osrf
             type: stable
+          - name: osrf
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-sensors9
@@ -105,11 +127,7 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: nightly
-    - name: gz-tools3
-      repositories:
-          - name: osrf
-            type: stable
+            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-transport14
@@ -117,14 +135,28 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: gz-utils3
       repositories:
           - name: osrf
             type: stable
           - name: osrf
+            type: prerelease
+          - name: osrf
             type: nightly
     - name: sdformat15
+      repositories:
+          - name: osrf
+            type: stable
+          - name: osrf
+            type: prerelease
+          - name: osrf
+            type: nightly
+
+    # Use nightlies in all main branches
+    - name: gz-tools3
       repositories:
           - name: osrf
             type: stable

--- a/plugins/ign-docker-env.py
+++ b/plugins/ign-docker-env.py
@@ -118,7 +118,7 @@ def normalize_args(args):
 def main():
     try:
         ignition_version, linux_distro, docker_args, vol_args = normalize_args(
-            docopt(__doc__, version='gzdev-docker-env 0.1.0'))
+            docopt(str(__doc__), version='gzdev-docker-env 0.1.0'))
         rocker_cmd = build_rocker_command(ignition_version, linux_distro, docker_args, vol_args)
         _check_call(rocker_cmd)
     except KeyError:

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -306,7 +306,7 @@ def remove_all_installed():
 
 def main():
     try:
-        args = normalize_args(docopt(__doc__,
+        args = normalize_args(docopt(str(__doc__),
                                      version='gzdev-repository 0.2.0'))
         config = load_config_file()
         validate_input(args)


### PR DESCRIPTION
Enable prereleases in all Ionic branches (some `main` and some with stable ranches like `gz-cmake4`). The goal is to be able to use prereleases for the tutorial party but still keep nightlies to expedite iterating on existing PRs.