### PR TITLE
Support for ROS repositories in the repository module

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,6 +50,14 @@ jobs:
              python3 ./gzdev.py repository purge
           grep "/etc/apt/sources.list.d/_gzdev_${repo_to_test}_${repo_type_to_test}.list" log
           grep "/usr/share/keyrings/_gzdev_${repo_to_test}_${repo_type_to_test}.gpg" log
+      - name: Smoke system tests for all the repositories
+        run: |
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+              python3 ./gzdev.py repository enable osrf stable
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+              python3 ./gzdev.py repository enable ros2 main
+          sudo env "PYTHONPATH=$pythonLocation/lib/python${{ matrix.python-version}}/site-packages" \
+              python3 ./gzdev.py repository enable ros_bootstrap main
       - name: Smoke system tests for ign-docker module
         run: |
           python3 gzdev.py ign-docker-env citadel

--- a/.github/workflows/pyright.yml
+++ b/.github/workflows/pyright.yml
@@ -15,4 +15,4 @@ jobs:
           source .venv/bin/activate
           pip install -r requirements.txt
       - run: echo "$PWD/.venv/bin" >> $GITHUB_PATH
-      - uses: jakebailey/pyright-action@1a4bf406072a8d0efdf6faba94a34a096430472f # v2
+      - uses: jakebailey/pyright-action@b5d50e5cde6547546a5c4ac92e416a8c2c1a1dfe # v 2.3.2

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -31,7 +31,7 @@ repositories:
           url: http://packages.ros.org/ros2/ubuntu
         - name: testing
           url: http://packages.ros.org/ros2-testing/ubuntu
-    - name: ros-bootstrap
+    - name: ros_bootstrap
       key: 4732CE706CD7B19DB0FFE74E8EDB2EF661FC880E
       key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4732ce706cd7b19db0ffe74e8edb2ef661fc880e
       linux_distro: ubuntu

--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -22,7 +22,22 @@ repositories:
             url: http://packages.osrfoundation.org/gazebo/debian-prerelease
           - name: nightly
             url: http://packages.osrfoundation.org/gazebo/debian-nightly
-
+    - name: ros2
+      key: C1CF6E31E6BADE8868B172B4F42ED6FBAB17C654
+      key_url: https://raw.githubusercontent.com/ros/rosdistro/master/ros.key
+      linux_distro: ubuntu
+      types:
+        - name: main
+          url: http://packages.ros.org/ros2/ubuntu
+        - name: testing
+          url: http://packages.ros.org/ros2-testing/ubuntu
+    - name: ros-bootstrap
+      key: 4732CE706CD7B19DB0FFE74E8EDB2EF661FC880E
+      key_url: https://keyserver.ubuntu.com/pks/lookup?op=get&search=0x4732ce706cd7b19db0ffe74e8edb2ef661fc880e
+      linux_distro: ubuntu
+      types:
+          - name: main
+            url: http://repos.ros.org/repos/ros_bootstrap
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:

--- a/plugins/ign-docker-env.py
+++ b/plugins/ign-docker-env.py
@@ -117,6 +117,7 @@ def normalize_args(args):
 
 def main():
     try:
+        assert __doc__ is not None  # make pyright happy
         ignition_version, linux_distro, docker_args, vol_args = normalize_args(
             docopt(str(__doc__), version='gzdev-docker-env 0.1.0'))
         rocker_cmd = build_rocker_command(ignition_version, linux_distro, docker_args, vol_args)

--- a/plugins/ign-docker-env.py
+++ b/plugins/ign-docker-env.py
@@ -117,7 +117,6 @@ def normalize_args(args):
 
 def main():
     try:
-        assert __doc__ is not None  # make pyright happy
         ignition_version, linux_distro, docker_args, vol_args = normalize_args(
             docopt(str(__doc__), version='gzdev-docker-env 0.1.0'))
         rocker_cmd = build_rocker_command(ignition_version, linux_distro, docker_args, vol_args)


### PR DESCRIPTION
This allow us to install the ROS repositories via gzdev in the same way that we install the Gazebo repositories. Added are the ros_bootstrap and the ROS 2 repositories. This last one with main and testing options.