### PR TITLE
Add eclipse zenoh repo for gz-transport15

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -38,6 +38,15 @@ repositories:
       types:
           - name: main
             url: http://repos.ros.org/repos/ros_bootstrap
+    - name: eclipse-zenoh
+      key: null
+      key_url: null
+      linux_distro: ubuntu
+      types:
+          - name: stable
+            url: https://download.eclipse.org/zenoh/debian-repo/
+            suite: /
+
 # wildcards are allowed in name, entries are processed in top-down order
 # first entry matching the name is used
 projects:
@@ -90,6 +99,8 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+          - name: eclipse-zenoh
+            type: stable
     - name: gz-fuel-tools11
       repositories:
           - name: osrf

--- a/plugins/repository.py
+++ b/plugins/repository.py
@@ -131,6 +131,7 @@ def get_repo_url(repo_name, repo_type, config):
 
     error('Unknown repository or type: ' + repo_name + '/' + repo_type)
 
+
 def get_repo_suite(repo_name, repo_type, config):
     for p in config['repositories']:
         if p['name'] == repo_name and p['linux_distro'].lower() == get_linux_distro():
@@ -139,6 +140,7 @@ def get_repo_suite(repo_name, repo_type, config):
                     if 'suite' in t:
                         return t['suite']
                     return None
+
 
 def get_sources_list_file_path(repo_name, repo_type):
     filename = f'{GZDEV_FILE_PREFIX}{repo_name}_{repo_type}.list'
@@ -217,6 +219,7 @@ def install_repo(repo_name, repo_type, config, linux_distro, gpg_check):
             distro_component_or_suite_str = f"{linux_distro} main"
 
         content = f"deb [{trusted_or_signed_str}] {url} {distro_component_or_suite_str}"
+        print(content)
         full_path = get_sources_list_file_path(repo_name, repo_type)
         if os.path.isfile(full_path):
             warn("gzdev file with the repositoy already exists in the system:"


### PR DESCRIPTION
Related PR: https://github.com/gazebosim/gz-transport/pull/600

Adds the eclipse zenoh repo to the repository.yaml config file. 

From zenoh [deb installation page](https://zenoh.io/docs/getting-started/installation/), the instruction to add their repo is

```
$ echo "deb [trusted=yes] https://download.eclipse.org/zenoh/debian-repo/ /" | sudo tee -a /etc/apt/sources.list > /dev/null
```

Some notes:
* it does not have gpg key signing so I updated the logic to support marking a repo as `trusted=yes` (instead of `signed-by=xxx.gpg`).
* the sources.list entry does not have the typical `deb {url} {distribution} {component}` format but it's in the form of `deb {url} {suite}` where suite in this case is just an absolute path `/`. So I modified the code to support this use case.

## Alternative considered

If we are not ok with trusting a repo without gpg signing, the alternative is to use ros2 repo's `ros-rolling-zenoh-cpp-vendor` package for gz-transport15. The caveat is that we will need to search for a different package name in cmake, i.e. `find_package(zenoh_cpp_vendor REQUIRED)`
