### PR TITLE
Add ros2 repo to gz-transport15 for zenoh package

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -90,6 +90,8 @@ projects:
             type: stable
           - name: osrf
             type: nightly
+          - name: ros2
+            type: main
     - name: gz-fuel-tools11
       repositories:
           - name: osrf


### PR DESCRIPTION
Alternative to https://github.com/gazebo-tooling/gzdev/pull/94

Use ros2 repo for zenoh packages instead of the eclipse-zenoh repo

Related PR: https://github.com/gazebosim/gz-transport/pull/614