### PR TITLE
Revert "Use prerelease in rotary for the Resolute transition (#105)"

### DIFF
--- a/plugins/config/repository.yaml
+++ b/plugins/config/repository.yaml
@@ -47,10 +47,8 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
-    # Use prerelease and nightlies for rotary libraries as workaround for
+    # Use nightlies for rotary libraries as workaround for
     # https://github.com/gazebo-tooling/gzdev/issues/102
     # TODO: remove when support for 102 is ready
     - name: gz-cmake6
@@ -58,15 +56,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-common8
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-fuel-tools12
@@ -74,15 +68,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-gui11
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-math10
@@ -90,15 +80,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-msgs13
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-physics10
@@ -106,15 +92,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-plugin5
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-rendering11
@@ -122,15 +104,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-sensors11
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-sim11
@@ -138,15 +116,11 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-tools3
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     - name: gz-transport16
@@ -154,23 +128,17 @@ projects:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: gz-utils5
       repositories:
           - name: osrf
             type: stable
           - name: osrf
-            type: prerelease
-          - name: osrf
             type: nightly
     - name: sdformat17
       repositories:
           - name: osrf
             type: stable
-          - name: osrf
-            type: prerelease
           - name: osrf
             type: nightly
     # generic regexp


### PR DESCRIPTION
This reverts commit 54fb00110ac646258d8422a6d85d0bbd7b5fda0a.

Breaking gz-sim rotary builds in `main`